### PR TITLE
feat: add paste text and URL source support to NotebookLM skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2025-12-11
+
+### Added
+- **Add Source Feature** - New `add_source.py` script to add sources directly to NotebookLM notebooks
+  - `--text` - Paste text content directly as a source
+  - `--file` - Read text file and paste as source
+  - `--url` - Add website or YouTube URLs as sources
+  - Supports notebook library integration (`--notebook-id`)
+  - Debug mode with `--show-browser` flag
+
+- **New Selectors in config.py** - UI selectors for add source workflow
+  - `ADD_SOURCE_BUTTON_SELECTORS` - Find the add sources button
+  - `PASTE_TEXT_CHIP_SELECTORS` - Select "Copied text" option
+  - `PASTE_TEXT_TEXTAREA_SELECTORS` - Text input field
+  - `INSERT_BUTTON_SELECTORS` - Submit button
+  - Additional dialog navigation selectors
+
+### Changed
+- **SKILL.md Documentation** - Added comprehensive add source documentation
+  - New "Add Sources" section in Script Reference
+  - Detailed usage examples for all source types
+  - Updated limitations section
+
 ## [1.3.0] - 2025-11-21
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -165,6 +165,14 @@ python scripts/run.py notebook_manager.py stats
 python scripts/run.py ask_question.py --question "..." [--notebook-id ID] [--notebook-url URL] [--show-browser]
 ```
 
+### Add Sources (`add_source.py`)
+```bash
+python scripts/run.py add_source.py --notebook-url URL --text "content"      # Paste text
+python scripts/run.py add_source.py --notebook-url URL --file /path/to/file  # From file
+python scripts/run.py add_source.py --notebook-url URL --url "https://..."   # Website/YouTube
+python scripts/run.py add_source.py --notebook-id ID --text "content"        # Use library
+```
+
 ### Data Cleanup (`cleanup_manager.py`)
 ```bash
 python scripts/run.py cleanup_manager.py                    # Preview cleanup
@@ -248,12 +256,57 @@ Synthesize and respond to user
 5. **Include context** - Each question is independent
 6. **Synthesize answers** - Combine multiple responses
 
+## Adding Sources to Notebooks (`add_source.py`)
+
+Add sources directly to NotebookLM notebooks via browser automation.
+
+### Add Text Source
+```bash
+# Add text directly
+python scripts/run.py add_source.py --notebook-url URL --text "Your text content here"
+
+# Add text from a file
+python scripts/run.py add_source.py --notebook-url URL --file /path/to/document.txt
+
+# Use notebook from library
+python scripts/run.py add_source.py --notebook-id my-notebook --text "Content"
+
+# Show browser for debugging
+python scripts/run.py add_source.py --notebook-url URL --text "Content" --show-browser
+```
+
+### Add URL Source (Website/YouTube)
+```bash
+# Add a website
+python scripts/run.py add_source.py --notebook-url URL --url "https://example.com/article"
+
+# Add a YouTube video
+python scripts/run.py add_source.py --notebook-url URL --url "https://youtube.com/watch?v=..."
+```
+
+### Source Types Supported
+| Type | Flag | Notes |
+|------|------|-------|
+| **Paste Text** | `--text "..."` | Direct text content |
+| **Text File** | `--file path` | Reads file and pastes as text |
+| **Website** | `--url https://...` | Any web page URL |
+| **YouTube** | `--url https://youtube.com/...` | YouTube video URLs |
+
+### Workflow: Add Source Then Query
+```bash
+# 1. Add your content as a source
+python scripts/run.py add_source.py --notebook-id my-notebook --file ./documentation.md
+
+# 2. Query the notebook about the new content
+python scripts/run.py ask_question.py --notebook-id my-notebook --question "Summarize the key points"
+```
+
 ## Limitations
 
 - No session persistence (each question = new browser)
 - Rate limits on free Google accounts (50 queries/day)
-- Manual upload required (user must add docs to NotebookLM)
 - Browser overhead (few seconds per question)
+- Large text sources may take time to process
 
 ## Resources (Skill Structure)
 

--- a/scripts/add_source.py
+++ b/scripts/add_source.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""
+Add sources to NotebookLM notebooks
+Supports: Paste text, Website URLs, YouTube URLs
+
+Each source addition opens a fresh browser session, adds the source, and closes.
+"""
+
+import argparse
+import sys
+import time
+import re
+from pathlib import Path
+
+from patchright.sync_api import sync_playwright
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from auth_manager import AuthManager
+from notebook_manager import NotebookLibrary
+from config import (
+    DATA_DIR,
+    ADD_SOURCE_BUTTON_SELECTORS,
+    PASTE_TEXT_CHIP_SELECTORS,
+    PASTE_TEXT_TEXTAREA_SELECTORS,
+    INSERT_BUTTON_SELECTORS,
+    URL_CHIP_SELECTORS,
+    URL_INPUT_SELECTORS,
+)
+from browser_utils import BrowserFactory, StealthUtils
+
+
+def add_text_source(notebook_url: str, content: str, headless: bool = True) -> str:
+    """
+    Add pasted text as a source to a NotebookLM notebook.
+
+    Args:
+        notebook_url: NotebookLM notebook URL
+        content: Text content to add as source
+        headless: Run browser in headless mode
+
+    Returns:
+        Success message or None on failure
+    """
+    auth = AuthManager()
+
+    if not auth.is_authenticated():
+        print("⚠️ Not authenticated. Run: python scripts/run.py auth_manager.py setup")
+        return None
+
+    if not content or not content.strip():
+        print("❌ Content cannot be empty")
+        return None
+
+    # Truncate content preview for logging
+    content_preview = content[:100] + "..." if len(content) > 100 else content
+    print(f"📝 Adding text source ({len(content)} chars)")
+    print(f"  Preview: {content_preview}")
+    print(f"📚 Notebook: {notebook_url}")
+
+    playwright = None
+    context = None
+
+    try:
+        playwright = sync_playwright().start()
+        context = BrowserFactory.launch_persistent_context(playwright, headless=headless)
+        page = context.new_page()
+
+        # Navigate to notebook
+        print("  🌐 Opening notebook...")
+        page.goto(notebook_url, wait_until="domcontentloaded")
+        page.wait_for_url(re.compile(r"^https://notebooklm\.google\.com/"), timeout=10000)
+        time.sleep(3)  # Let UI render
+
+        # Check if we're on the notebook page
+        if "/notebook/" not in page.url:
+            print(f"  ❌ Redirected away from notebook: {page.url}")
+            return None
+
+        # Click Sources tab if visible
+        try:
+            sources_tab = page.query_selector('button:has-text("Sources"), [role="tab"]:has-text("Sources")')
+            if sources_tab and sources_tab.is_visible():
+                sources_tab.click()
+                time.sleep(1)
+        except:
+            pass
+
+        # Find and click "Add sources" button
+        print("  ⏳ Looking for Add sources button...")
+        add_btn = None
+        for selector in ADD_SOURCE_BUTTON_SELECTORS:
+            try:
+                add_btn = page.wait_for_selector(selector, timeout=5000, state="visible")
+                if add_btn:
+                    print(f"  ✓ Found: {selector}")
+                    break
+            except:
+                continue
+
+        if not add_btn:
+            # Take debug screenshot
+            debug_path = DATA_DIR / "add_source_debug.png"
+            page.screenshot(path=str(debug_path))
+            print(f"  ❌ Could not find Add sources button")
+            print(f"  📸 Debug screenshot: {debug_path}")
+            return None
+
+        add_btn.click()
+        time.sleep(1.5)
+
+        # Click "Copied text" chip
+        print("  ⏳ Selecting 'Copied text' option...")
+        chip = None
+        for selector in PASTE_TEXT_CHIP_SELECTORS:
+            try:
+                chip = page.wait_for_selector(selector, timeout=3000, state="visible")
+                if chip:
+                    print(f"  ✓ Found: {selector}")
+                    break
+            except:
+                continue
+
+        if not chip:
+            print("  ❌ Could not find 'Copied text' option")
+            return None
+
+        chip.click()
+        time.sleep(1)
+
+        # Find textarea and enter content
+        print("  ⏳ Entering text content...")
+        textarea = None
+        for selector in PASTE_TEXT_TEXTAREA_SELECTORS:
+            try:
+                textarea = page.wait_for_selector(selector, timeout=3000, state="visible")
+                if textarea:
+                    print(f"  ✓ Found: {selector}")
+                    break
+            except:
+                continue
+
+        if not textarea:
+            print("  ❌ Could not find text input")
+            return None
+
+        textarea.click()
+        StealthUtils.random_delay(200, 400)
+
+        # Use fill() for large content, human_type for small
+        if len(content) > 500:
+            textarea.fill(content)
+        else:
+            StealthUtils.human_type(page, PASTE_TEXT_TEXTAREA_SELECTORS[0], content)
+
+        time.sleep(0.5)
+
+        # Click Insert button
+        print("  ⏳ Clicking Insert...")
+        time.sleep(1)  # Wait for button to enable
+
+        insert_btn = None
+        for selector in INSERT_BUTTON_SELECTORS:
+            try:
+                insert_btn = page.wait_for_selector(selector, timeout=3000, state="visible")
+                if insert_btn:
+                    print(f"  ✓ Found: {selector}")
+                    break
+            except:
+                continue
+
+        if not insert_btn:
+            print("  ❌ Could not find Insert button")
+            return None
+
+        insert_btn.click()
+        time.sleep(3)  # Wait for source to be added
+
+        # Check for errors
+        try:
+            error = page.query_selector('[class*="error"]')
+            if error and error.is_visible():
+                print(f"  ❌ Error: {error.inner_text().strip()}")
+                return None
+        except:
+            pass
+
+        print("  ✅ Text source added!")
+        return f"Successfully added text source ({len(content)} characters)"
+
+    except Exception as e:
+        print(f"  ❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return None
+
+    finally:
+        if context:
+            try:
+                context.close()
+            except:
+                pass
+        if playwright:
+            try:
+                playwright.stop()
+            except:
+                pass
+
+
+def add_url_source(notebook_url: str, source_url: str, headless: bool = True) -> str:
+    """
+    Add a website or YouTube URL as a source to a NotebookLM notebook.
+
+    Args:
+        notebook_url: NotebookLM notebook URL
+        source_url: Website or YouTube URL to add
+        headless: Run browser in headless mode
+
+    Returns:
+        Success message or None on failure
+    """
+    auth = AuthManager()
+
+    if not auth.is_authenticated():
+        print("⚠️ Not authenticated. Run: python scripts/run.py auth_manager.py setup")
+        return None
+
+    if not source_url or not source_url.strip():
+        print("❌ URL cannot be empty")
+        return None
+
+    # Determine source type
+    is_youtube = "youtube.com" in source_url or "youtu.be" in source_url
+    source_type = "YouTube" if is_youtube else "Website"
+
+    print(f"🔗 Adding {source_type} source")
+    print(f"  URL: {source_url}")
+    print(f"📚 Notebook: {notebook_url}")
+
+    playwright = None
+    context = None
+
+    try:
+        playwright = sync_playwright().start()
+        context = BrowserFactory.launch_persistent_context(playwright, headless=headless)
+        page = context.new_page()
+
+        # Navigate to notebook
+        print("  🌐 Opening notebook...")
+        page.goto(notebook_url, wait_until="domcontentloaded")
+        page.wait_for_url(re.compile(r"^https://notebooklm\.google\.com/"), timeout=10000)
+        time.sleep(3)
+
+        # Click Sources tab if visible
+        try:
+            sources_tab = page.query_selector('button:has-text("Sources"), [role="tab"]:has-text("Sources")')
+            if sources_tab and sources_tab.is_visible():
+                sources_tab.click()
+                time.sleep(1)
+        except:
+            pass
+
+        # Find and click "Add sources" button
+        print("  ⏳ Looking for Add sources button...")
+        add_btn = None
+        for selector in ADD_SOURCE_BUTTON_SELECTORS:
+            try:
+                add_btn = page.wait_for_selector(selector, timeout=5000, state="visible")
+                if add_btn:
+                    break
+            except:
+                continue
+
+        if not add_btn:
+            print("  ❌ Could not find Add sources button")
+            return None
+
+        add_btn.click()
+        time.sleep(1.5)
+
+        # Click Website or YouTube chip
+        print(f"  ⏳ Selecting '{source_type}' option...")
+        chip = None
+        chip_selector = f'mat-chip:has-text("{source_type}")'
+        for selector in [chip_selector] + URL_CHIP_SELECTORS:
+            try:
+                chip = page.wait_for_selector(selector, timeout=3000, state="visible")
+                if chip:
+                    break
+            except:
+                continue
+
+        if not chip:
+            print(f"  ❌ Could not find '{source_type}' option")
+            return None
+
+        chip.click()
+        time.sleep(1)
+
+        # Find URL input and enter URL
+        print("  ⏳ Entering URL...")
+        url_input = None
+        for selector in URL_INPUT_SELECTORS:
+            try:
+                url_input = page.wait_for_selector(selector, timeout=3000, state="visible")
+                if url_input:
+                    break
+            except:
+                continue
+
+        if not url_input:
+            print("  ❌ Could not find URL input")
+            return None
+
+        url_input.click()
+        StealthUtils.random_delay(200, 400)
+        url_input.fill(source_url)
+        time.sleep(0.5)
+
+        # Click Insert button
+        print("  ⏳ Submitting...")
+        insert_btn = None
+        for selector in INSERT_BUTTON_SELECTORS:
+            try:
+                insert_btn = page.query_selector(selector)
+                if insert_btn and insert_btn.is_visible():
+                    insert_btn.click()
+                    break
+            except:
+                continue
+
+        if not insert_btn:
+            # Fallback to Enter key
+            page.keyboard.press("Enter")
+
+        time.sleep(4)  # Wait for URL to be processed
+
+        print(f"  ✅ {source_type} source added!")
+        return f"Successfully added {source_type} source: {source_url}"
+
+    except Exception as e:
+        print(f"  ❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return None
+
+    finally:
+        if context:
+            try:
+                context.close()
+            except:
+                pass
+        if playwright:
+            try:
+                playwright.stop()
+            except:
+                pass
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Add sources to NotebookLM notebooks')
+
+    parser.add_argument('--notebook-url', help='NotebookLM notebook URL')
+    parser.add_argument('--notebook-id', help='Notebook ID from library')
+
+    # Source types (mutually exclusive)
+    source_group = parser.add_mutually_exclusive_group(required=True)
+    source_group.add_argument('--text', help='Text content to paste as source')
+    source_group.add_argument('--file', help='Path to text file to read and paste')
+    source_group.add_argument('--url', help='Website or YouTube URL to add')
+
+    parser.add_argument('--show-browser', action='store_true', help='Show browser')
+
+    args = parser.parse_args()
+
+    # Resolve notebook URL
+    notebook_url = args.notebook_url
+
+    if not notebook_url and args.notebook_id:
+        library = NotebookLibrary()
+        notebook = library.get_notebook(args.notebook_id)
+        if notebook:
+            notebook_url = notebook['url']
+            print(f"📚 Using notebook: {notebook['name']}")
+        else:
+            print(f"❌ Notebook '{args.notebook_id}' not found")
+            return 1
+
+    if not notebook_url:
+        # Try active notebook
+        library = NotebookLibrary()
+        active = library.get_active_notebook()
+        if active:
+            notebook_url = active['url']
+            print(f"📚 Using active notebook: {active['name']}")
+        else:
+            print("❌ No notebook specified. Use --notebook-url or --notebook-id")
+            return 1
+
+    # Execute based on source type
+    result = None
+
+    if args.text:
+        result = add_text_source(
+            notebook_url=notebook_url,
+            content=args.text,
+            headless=not args.show_browser
+        )
+
+    elif args.file:
+        file_path = Path(args.file)
+        if not file_path.exists():
+            print(f"❌ File not found: {args.file}")
+            return 1
+
+        print(f"📄 Reading: {args.file}")
+        content = file_path.read_text(encoding='utf-8')
+        print(f"  Size: {len(content)} characters")
+
+        result = add_text_source(
+            notebook_url=notebook_url,
+            content=content,
+            headless=not args.show_browser
+        )
+
+    elif args.url:
+        result = add_url_source(
+            notebook_url=notebook_url,
+            source_url=args.url,
+            headless=not args.show_browser
+        )
+
+    # Print result
+    print("\n" + "=" * 50)
+    if result:
+        print(f"✅ {result}")
+        return 0
+    else:
+        print("❌ Failed to add source")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -42,3 +42,64 @@ USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
 LOGIN_TIMEOUT_MINUTES = 10
 QUERY_TIMEOUT_SECONDS = 120
 PAGE_LOAD_TIMEOUT = 30000
+
+# Add Source Selectors
+ADD_SOURCE_BUTTON_SELECTORS = [
+    'button.add-source-button',
+    'button[aria-label="Add source"]',
+    'button:has-text("Add sources")',
+    'button:has-text("Upload a source")',  # Empty notebook state
+    'button:has-text("+ Add sources")',
+]
+
+# Paste Text Flow Selectors
+PASTE_TEXT_CHIP_SELECTORS = [
+    'mat-chip:has-text("Copied text")',
+    'button:has-text("Copied text")',
+    '[class*="chip"]:has-text("Copied text")',
+]
+
+PASTE_TEXT_TEXTAREA_SELECTORS = [
+    'textarea.text-area',
+    '[role="dialog"] textarea.mat-mdc-input-element',
+    '[role="dialog"] textarea',
+]
+
+INSERT_BUTTON_SELECTORS = [
+    '[role="dialog"] button:has-text("Insert")',
+    'button[type="submit"]:has-text("Insert")',
+    'button:has-text("Insert")',
+]
+
+CLOSE_DIALOG_BUTTON_SELECTORS = [
+    'button[aria-label="Close dialog"]',
+    '[role="dialog"] button:has-text("close")',
+]
+
+BACK_TO_SOURCES_BUTTON_SELECTORS = [
+    'button[aria-label="Return to upload sources dialog"]',
+    '[role="dialog"] button:has-text("arrow_back")',
+]
+
+# Source verification
+SOURCE_ITEM_SELECTORS = [
+    '.source-item',
+    '[class*="source-list"] [class*="item"]',
+    '.sources-list .source',
+]
+
+# URL Source Selectors (Website/YouTube)
+URL_CHIP_SELECTORS = [
+    'mat-chip:has-text("Website")',
+    'mat-chip:has-text("YouTube")',
+    'button:has-text("Website")',
+    'button:has-text("YouTube")',
+]
+
+URL_INPUT_SELECTORS = [
+    'textarea.text-area',
+    'textarea[placeholder*="URL" i]',
+    'textarea[placeholder*="Paste" i]',
+    '[role="dialog"] textarea',
+    'input[placeholder*="URL" i]',
+]


### PR DESCRIPTION
## Summary

I came across this skill while planning to build my own NotebookLM integration - really liked what you've built here! I'm a big fan of NotebookLM and this skill is exactly what I was looking for.

I noticed a small gap in adding sources programmatically, so I thought I'd contribute. For now, this PR adds copy/paste text as a source option. Planning to integrate a file picker in a future PR.

## Changes

| File | Description |
|------|-------------|
| `scripts/add_source.py` | New script for adding sources |
| `scripts/config.py` | Added selectors for add source UI |
| `SKILL.md` | Documentation for add_source.py |
| `CHANGELOG.md` | v1.4.0 release notes |

## Features Added

- **Paste text** (`--text`) - Add text content directly as a source
- **From file** (`--file`) - Read a text file and paste as source  
- **URL sources** (`--url`) - Add website or YouTube URLs

## Usage

```bash
# Paste text directly
python scripts/run.py add_source.py --notebook-id ID --text "content"

# From file
python scripts/run.py add_source.py --notebook-id ID --file /path/to/doc.txt

# Website/YouTube URL
python scripts/run.py add_source.py --notebook-id ID --url "https://..."
```

## Future Plans

- File picker integration for native file uploads (PDF, audio, etc.)

## Test plan

- [ ] Test paste text source
- [ ] Test file source
- [ ] Test website URL source
- [ ] Test YouTube URL source