### PR TITLE
Docs: Add Google Antigravity installation instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The web UI runs skills in a sandbox without network access, which this skill req
 ## The Problem
 
 When you tell [Claude Code](https://github.com/anthropics/claude-code) to "search through my local documentation", here's what happens:
+
 - **Massive token consumption**: Searching through documentation means reading multiple files repeatedly
 - **Inaccurate retrieval**: Searches for keywords, misses context and connections between docs
 - **Hallucinations**: When it can't find something, it invents plausible-sounding APIs
@@ -47,12 +48,12 @@ Your Task → Claude asks NotebookLM → Gemini synthesizes answer → Claude wr
 
 ## Why NotebookLM, Not Local RAG?
 
-| Approach | Token Cost | Setup Time | Hallucinations | Answer Quality |
-|----------|------------|------------|----------------|----------------|
-| **Feed docs to Claude** | 🔴 Very high (multiple file reads) | Instant | Yes - fills gaps | Variable retrieval |
-| **Web search** | 🟡 Medium | Instant | High - unreliable sources | Hit or miss |
-| **Local RAG** | 🟡 Medium-High | Hours (embeddings, chunking) | Medium - retrieval gaps | Depends on setup |
-| **NotebookLM Skill** | 🟢 Minimal | 5 minutes | **Minimal** - source-grounded only | Expert synthesis |
+| Approach                | Token Cost                         | Setup Time                   | Hallucinations                     | Answer Quality     |
+| ----------------------- | ---------------------------------- | ---------------------------- | ---------------------------------- | ------------------ |
+| **Feed docs to Claude** | 🔴 Very high (multiple file reads) | Instant                      | Yes - fills gaps                   | Variable retrieval |
+| **Web search**          | 🟡 Medium                          | Instant                      | High - unreliable sources          | Hit or miss        |
+| **Local RAG**           | 🟡 Medium-High                     | Hours (embeddings, chunking) | Medium - retrieval gaps            | Depends on setup   |
+| **NotebookLM Skill**    | 🟢 Minimal                         | 5 minutes                    | **Minimal** - source-grounded only | Expert synthesis   |
 
 ### What Makes NotebookLM Superior?
 
@@ -80,7 +81,25 @@ git clone https://github.com/PleasePrompto/notebooklm-skill notebooklm
 "What are my skills?"
 ```
 
+### Google Antigravity Installation
+
+1. Clone this repository:
+
+   ```bash
+   git clone https://github.com/PleasePrompto/notebooklm-skill temp_notebooklm
+   ```
+
+2. Copy the skill to your global skills directory:
+
+   - **Windows**: `%USERPROFILE%\.gemini\antigravity\skills\notebooklm-skill`
+   - **Mac/Linux**: `~/.gemini/antigravity/skills/notebooklm-skill`
+
+3. (Optional) Clean up the temporary directory.
+
+For more details on managing skills, please refer to the [official documentation](https://antigravity.google/docs/skills).
+
 When you first use the skill, it automatically:
+
 - Creates an isolated Python environment (`.venv`)
 - Installs all dependencies including **Google Chrome**
 - Sets up browser automation with Chrome (not Chromium) for maximum reliability
@@ -95,6 +114,7 @@ When you first use the skill, it automatically:
 ### 1. Check your skills
 
 Say in Claude Code:
+
 ```
 "What skills do I have?"
 ```
@@ -106,11 +126,13 @@ Claude will list your available skills including NotebookLM.
 ```
 "Set up NotebookLM authentication"
 ```
-*A Chrome window opens → log in with your Google account*
+
+_A Chrome window opens → log in with your Google account_
 
 ### 3. Create your knowledge base
 
 Go to [notebooklm.google.com](https://notebooklm.google.com) → Create notebook → Upload your docs:
+
 - 📄 PDFs, Google Docs, markdown files
 - 🔗 Websites, GitHub repos
 - 🎥 YouTube videos
@@ -121,15 +143,19 @@ Share: **⚙️ Share → Anyone with link → Copy**
 ### 4. Add to your library
 
 **Option A: Let Claude figure it out (Smart Add)**
+
 ```
 "Query this notebook about its content and add it to my library: [your-link]"
 ```
+
 Claude will automatically query the notebook to discover its content, then add it with appropriate metadata.
 
 **Option B: Manual add**
+
 ```
 "Add this NotebookLM to my library: [your-link]"
 ```
+
 Claude will ask for a name and topics, then save it for future use.
 
 ### 5. Start researching
@@ -148,14 +174,14 @@ This is a **Claude Code Skill** - a local folder containing instructions and scr
 
 ### Key Differences from MCP Server
 
-| Feature | This Skill | MCP Server |
-|---------|------------|------------|
-| **Protocol** | Claude Skills | Model Context Protocol |
-| **Installation** | Clone to `~/.claude/skills` | `claude mcp add ...` |
-| **Sessions** | Fresh browser each question | Persistent chat sessions |
-| **Compatibility** | Claude Code only (local) | Claude Code, Codex, Cursor, etc. |
-| **Language** | Python | TypeScript |
-| **Distribution** | Git clone | npm package |
+| Feature           | This Skill                  | MCP Server                       |
+| ----------------- | --------------------------- | -------------------------------- |
+| **Protocol**      | Claude Skills               | Model Context Protocol           |
+| **Installation**  | Clone to `~/.claude/skills` | `claude mcp add ...`             |
+| **Sessions**      | Fresh browser each question | Persistent chat sessions         |
+| **Compatibility** | Claude Code only (local)    | Claude Code, Codex, Cursor, etc. |
+| **Language**      | Python                      | TypeScript                       |
+| **Distribution**  | Git clone                   | npm package                      |
 
 ### Architecture
 
@@ -171,6 +197,7 @@ This is a **Claude Code Skill** - a local folder containing instructions and scr
 ```
 
 When you mention NotebookLM or send a notebook URL, Claude:
+
 1. Loads the skill instructions
 2. Runs the appropriate Python script
 3. Opens a browser, asks your question
@@ -182,35 +209,41 @@ When you mention NotebookLM or send a notebook URL, Claude:
 ## Core Features
 
 ### **Source-Grounded Responses**
+
 NotebookLM significantly reduces hallucinations by answering exclusively from your uploaded documents. If information isn't available, it indicates uncertainty rather than inventing content.
 
 ### **Direct Integration**
+
 No copy-paste between browser and editor. Claude asks and receives answers programmatically.
 
 ### **Smart Library Management**
+
 Save NotebookLM links with tags and descriptions. Claude auto-selects the right notebook for your task.
 
 ### **Automatic Authentication**
+
 One-time Google login, then authentication persists across sessions.
 
 ### **Self-Contained**
+
 Everything runs in the skill folder with an isolated Python environment. No global installations.
 
 ### **Human-Like Automation**
+
 Uses realistic typing speeds and interaction patterns to avoid detection.
 
 ---
 
 ## Common Commands
 
-| What you say | What happens |
-|--------------|--------------|
-| *"Set up NotebookLM authentication"* | Opens Chrome for Google login |
-| *"Add [link] to my NotebookLM library"* | Saves notebook with metadata |
-| *"Show my NotebookLM notebooks"* | Lists all saved notebooks |
-| *"Ask my API docs about [topic]"* | Queries the relevant notebook |
-| *"Use the React notebook"* | Sets active notebook |
-| *"Clear NotebookLM data"* | Fresh start (keeps library) |
+| What you say                            | What happens                  |
+| --------------------------------------- | ----------------------------- |
+| _"Set up NotebookLM authentication"_    | Opens Chrome for Google login |
+| _"Add [link] to my NotebookLM library"_ | Saves notebook with metadata  |
+| _"Show my NotebookLM notebooks"_        | Lists all saved notebooks     |
+| _"Ask my API docs about [topic]"_       | Queries the relevant notebook |
+| _"Use the React notebook"_              | Sets active notebook          |
+| _"Clear NotebookLM data"_               | Fresh start (keeps library)   |
 
 ---
 
@@ -221,6 +254,7 @@ Uses realistic typing speeds and interaction patterns to avoid detection.
 **User asks**: "Check my Suzuki GSR 600 workshop manual for brake fluid type, engine oil specs, and rear axle torque."
 
 **Claude automatically**:
+
 - Authenticates with NotebookLM
 - Asks comprehensive questions about each specification
 - Follows up when prompted "Is that ALL you need to know?"
@@ -233,6 +267,7 @@ Uses realistic typing speeds and interaction patterns to avoid detection.
 **You**: "I need to build an n8n workflow for Gmail spam filtering. Use my n8n notebook."
 
 **Claude's internal process:**
+
 ```
 → Loads NotebookLM skill
 → Activates n8n notebook
@@ -247,6 +282,7 @@ Uses realistic typing speeds and interaction patterns to avoid detection.
 ## Technical Details
 
 ### Core Technology
+
 - **Patchright**: Browser automation library (Playwright-based)
 - **Python**: Implementation language for this skill
 - **Stealth techniques**: Human-like typing and interaction patterns
@@ -254,6 +290,7 @@ Uses realistic typing speeds and interaction patterns to avoid detection.
 Note: The MCP server uses the same Patchright library but via TypeScript/npm ecosystem.
 
 ### Dependencies
+
 - **patchright==1.55.2**: Browser automation
 - **python-dotenv==1.0.0**: Environment configuration
 - Automatically installed in `.venv` on first use
@@ -270,6 +307,7 @@ All data is stored locally within the skill directory:
 ```
 
 **Important Security Note:**
+
 - The `data/` directory contains sensitive authentication data and personal notebooks
 - It's automatically excluded from git via `.gitignore`
 - NEVER manually commit or share the contents of the `data/` directory
@@ -277,12 +315,14 @@ All data is stored locally within the skill directory:
 ### Session Model
 
 Unlike the MCP server, this skill uses a **stateless model**:
+
 - Each question opens a fresh browser
 - Asks the question, gets the answer
 - Adds a follow-up prompt to encourage Claude to ask more questions
 - Closes the browser immediately
 
 This means:
+
 - No persistent chat context
 - Each question is independent
 - But your notebook library persists
@@ -295,11 +335,13 @@ For multi-step research, Claude automatically asks follow-up questions when need
 ## Limitations
 
 ### Skill-Specific
+
 - **Local Claude Code only** - Does not work in web UI (sandbox restrictions)
 - **No session persistence** - Each question is independent
 - **No follow-up context** - Can't reference "the previous answer"
 
 ### NotebookLM
+
 - **Rate limits** - Free tier has daily query limits
 - **Manual upload** - You must upload docs to NotebookLM first
 - **Share requirement** - Notebooks must be shared publicly
@@ -328,6 +370,7 @@ Chrome runs locally on your machine. Your credentials never leave your computer.
 ## Troubleshooting
 
 ### Skill not found
+
 ```bash
 # Make sure it's in the right location
 ls ~/.claude/skills/notebooklm/
@@ -335,12 +378,15 @@ ls ~/.claude/skills/notebooklm/
 ```
 
 ### Authentication issues
+
 Say: `"Reset NotebookLM authentication"`
 
 ### Browser crashes
+
 Say: `"Clear NotebookLM browser data"`
 
 ### Dependencies issues
+
 ```bash
 # Manual reinstall if needed
 cd ~/.claude/skills/notebooklm
@@ -361,6 +407,7 @@ While I've built in humanization features (realistic typing speeds, natural dela
 
 **About CLI tools and AI agents:**
 CLI tools like Claude Code, Codex, and similar AI-powered assistants are incredibly powerful, but they can make mistakes. Please use them with care and awareness:
+
 - Always review changes before committing or deploying
 - Test in safe environments first
 - Keep backups of important work
@@ -375,11 +422,13 @@ That said, if you run into problems or have questions, feel free to open an issu
 ## Credits
 
 This skill is inspired by my [**NotebookLM MCP Server**](https://github.com/PleasePrompto/notebooklm-mcp) and provides an alternative implementation as a Claude Code Skill:
+
 - Both use Patchright for browser automation (TypeScript for MCP, Python for Skill)
 - Skill version runs directly in Claude Code without MCP protocol
 - Stateless design optimized for skill architecture
 
 If you need:
+
 - **Persistent sessions** → Use the [MCP Server](https://github.com/PleasePrompto/notebooklm-mcp)
 - **Multiple tool support** (Codex, Cursor) → Use the [MCP Server](https://github.com/PleasePrompto/notebooklm-mcp)
 - **Quick Claude Code integration** → Use this skill

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ git clone https://github.com/PleasePrompto/notebooklm-skill notebooklm
 
 ### Google Antigravity Installation
 
+> **Prerequisite**: Please ensure you have read the [official documentation](https://antigravity.google/docs/skills) to understand how to install and manage skills in Google Antigravity.
+
 1. Clone this repository:
 
    ```bash
@@ -95,8 +97,6 @@ git clone https://github.com/PleasePrompto/notebooklm-skill notebooklm
    - **Mac/Linux**: `~/.gemini/antigravity/skills/notebooklm-skill`
 
 3. (Optional) Clean up the temporary directory.
-
-For more details on managing skills, please refer to the [official documentation](https://antigravity.google/docs/skills).
 
 When you first use the skill, it automatically:
 


### PR DESCRIPTION
Added a dedicated section for Google Antigravity users to install this skill, including the correct global skills directory path for Windows/Mac/Linux.